### PR TITLE
BRGD-114 Execute Command: Handle Command Not Found

### DIFF
--- a/src/Service/Commands/Controllers/CommandController.cs
+++ b/src/Service/Commands/Controllers/CommandController.cs
@@ -118,6 +118,10 @@ namespace Brighid.Commands.Commands
             {
                 return Forbid();
             }
+            catch (CommandNotFoundException)
+            {
+                return NotFound();
+            }
         }
     }
 }

--- a/tests/Service/Commands/Controllers/CommandControllerTests.cs
+++ b/tests/Service/Commands/Controllers/CommandControllerTests.cs
@@ -238,6 +238,24 @@ namespace Brighid.Commands.Commands
 
                 result.Should().BeOfType<ForbidResult>();
             }
+
+            [Test, Auto]
+            public async Task ShouldReturnNotFoundIfTheCommandWasNotFound(
+                string commandName,
+                HttpContext httpContext,
+                ExecuteCommandRequest request,
+                [Frozen, Substitute] ICommandRepository repository,
+                [Target] CommandController controller
+            )
+            {
+                controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+                repository.FindCommandByName(Any<string>(), Any<CancellationToken>()).Throws(new CommandNotFoundException(commandName));
+
+                var result = (await controller.Execute(commandName, request)).Result;
+
+                result.Should().BeOfType<NotFoundResult>();
+            }
         }
     }
 }


### PR DESCRIPTION
This handles a case in the execute command endpoint when the command is not found.