### PR TITLE
BRGD-171 Command Loader Scope Issue Fix

### DIFF
--- a/deploy/brighid-commands.template.yml
+++ b/deploy/brighid-commands.template.yml
@@ -36,6 +36,13 @@ Parameters:
     Type: String
     Description: Name to use for the node in the App Mesh.
 
+  EnvironmentName:
+    Type: String
+    Description: Name of the environment being deployed to.
+    AllowedValues:
+      - dev
+      - prod
+
 Resources:
   MeshService:
     Type: AWS::AppMesh::VirtualService
@@ -172,6 +179,8 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: brighid
           Environment:
+            - Name: ASPNETCORE_ENVIRONMENT
+              Value: !Ref EnvironmentName
             - Name: Database__Host
               Value: !ImportValue mutedac:ClusterAddress
             - Name: Database__Name

--- a/deploy/params/dev.json
+++ b/deploy/params/dev.json
@@ -6,5 +6,6 @@
   "OpenIdMetadataAddress": "http://identity.dev.brigh.id/.well-known/openid-configuration",
   "OpenIdValidIssuer": "https://identity.dev.brigh.id/",
   "EnvoyImage": "840364872350.dkr.ecr.us-east-1.amazonaws.com/aws-appmesh-envoy:v1.19.0.0-prod",
-  "MeshNodeName": "commands-dev"
+  "MeshNodeName": "commands-dev",
+  "EnvironmentName": "dev"
 }

--- a/deploy/params/prod.json
+++ b/deploy/params/prod.json
@@ -6,5 +6,6 @@
   "OpenIdMetadataAddress": "http://identity.brigh.id/.well-known/openid-configuration",
   "OpenIdValidIssuer": "https://identity.brigh.id/",
   "EnvoyImage": "840364872350.dkr.ecr.us-east-1.amazonaws.com/aws-appmesh-envoy:v1.19.0.0-prod",
-  "MeshNodeName": "commands-prod"
+  "MeshNodeName": "commands-prod",
+  "EnvironmentName": "prod"
 }

--- a/src/Service/Commands/Services/DefaultCommandLoader.cs
+++ b/src/Service/Commands/Services/DefaultCommandLoader.cs
@@ -6,20 +6,16 @@ namespace Brighid.Commands.Commands
     /// <inheritdoc />
     public class DefaultCommandLoader : ICommandLoader
     {
-        private readonly ICommandRepository repository;
         private readonly ICommandService service;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultCommandLoader"/> class.
         /// </summary>
-        /// <param name="repository">Repository layer for commands.</param>
         /// <param name="service">Service for managing commands.</param>
         public DefaultCommandLoader(
-            ICommandRepository repository,
             ICommandService service
         )
         {
-            this.repository = repository;
             this.service = service;
         }
 

--- a/src/Service/Constants.cs
+++ b/src/Service/Constants.cs
@@ -1,0 +1,29 @@
+namespace Brighid.Commands
+{
+    /// <summary>
+    /// Shared constants.
+    /// </summary>
+    public static class Constants
+    {
+        /// <summary>
+        /// Environment names.
+        /// </summary>
+        public static class Environments
+        {
+            /// <summary>
+            /// The local environment.
+            /// </summary>
+            public const string Local = "local";
+
+            /// <summary>
+            /// The dev environment.
+            /// </summary>
+            public const string Dev = "dev";
+
+            /// <summary>
+            /// The prod environment.
+            /// </summary>
+            public const string Prod = "prod";
+        }
+    }
+}

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -17,6 +17,8 @@ using Microsoft.OpenApi.Models;
 
 using Serilog;
 
+using Environments = Brighid.Commands.Constants.Environments;
+
 namespace Brighid.Commands
 {
     /// <summary>
@@ -78,7 +80,7 @@ namespace Brighid.Commands
         {
             logger.LogInformation("Starting. Environment: {@environment}", environment.EnvironmentName);
 
-            if (environment.IsEnvironment("local"))
+            if (environment.IsEnvironment(Environments.Local))
             {
                 databaseContext.Database.Migrate();
             }


### PR DESCRIPTION
This fixes an issue with the command loader where it was added to the container as a singleton, but consuming a scoped service (ICommandRepository).  This removes the command repository as a dependency, and turns on scope validation in lower environments so that these errors can be caught more easily in the future.