### PR TITLE
BRGD-128 Download Command on Create/Update

### DIFF
--- a/cicd/template.yml
+++ b/cicd/template.yml
@@ -138,7 +138,7 @@ Resources:
       DesiredCount: 1
       DeploymentConfiguration:
         MinimumHealthyPercent: 1
-        MaximumPercent: 200
+        MaximumPercent: 125
         DeploymentCircuitBreaker:
           Enable: true
           Rollback: true

--- a/src/Service/Commands/Controllers/CommandController.cs
+++ b/src/Service/Commands/Controllers/CommandController.cs
@@ -162,10 +162,8 @@ namespace Brighid.Commands.Service
 
             try
             {
-                var command = await repository.FindCommandByName(name, HttpContext.RequestAborted);
-                service.EnsureCommandIsAccessibleToPrincipal(command, HttpContext.User);
-                await loader.LoadCommand(command, HttpContext.RequestAborted);
-
+                var command = await service.GetByName(name, HttpContext.User, HttpContext.RequestAborted);
+                await service.LoadCommand(command, HttpContext.RequestAborted);
                 var context = new CommandContext(HttpContext.Request.Body, HttpContext.User, null!, null!);
 
                 // Embedded Commands are typically very fast once loaded into the Assembly Load Context.

--- a/src/Service/Commands/Extensions/CommandServiceCollectionExtensions.cs
+++ b/src/Service/Commands/Extensions/CommandServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ICommandService, DefaultCommandService>();
             services.AddSingleton<ICommandPackageDownloader, DefaultCommandPackageDownloader>();
             services.AddSingleton<ICommandLoader, DefaultCommandLoader>();
-            services.AddSingleton<IHostedService, StartupCommandLoader>();
+            services.AddSingleton<IHostedService, CommandLoaderBackgroundService>();
             services.AddScoped<ICommandRepository, DefaultCommandRepository>();
         }
     }

--- a/src/Service/Commands/HostedServices/CommandLoaderBackgroundService.cs
+++ b/src/Service/Commands/HostedServices/CommandLoaderBackgroundService.cs
@@ -9,22 +9,22 @@ namespace Brighid.Commands.Service
     /// <summary>
     /// Service that loads commands on startup.
     /// </summary>
-    public class StartupCommandLoader : IHostedService
+    public class CommandLoaderBackgroundService : IHostedService
     {
-        private readonly ICommandLoader loader;
-        private readonly ILogger<StartupCommandLoader> logger;
+        private readonly ICommandService commandService;
+        private readonly ILogger<CommandLoaderBackgroundService> logger;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="StartupCommandLoader" /> class.
+        /// Initializes a new instance of the <see cref="CommandLoaderBackgroundService" /> class.
         /// </summary>
-        /// <param name="loader">Service that provides command-loading functionality.</param>
+        /// <param name="commandService">Service that provides command-loading functionality.</param>
         /// <param name="logger">Service used to log information to some destination(s).</param>
-        public StartupCommandLoader(
-            ICommandLoader loader,
-            ILogger<StartupCommandLoader> logger
+        public CommandLoaderBackgroundService(
+            ICommandService commandService,
+            ILogger<CommandLoaderBackgroundService> logger
         )
         {
-            this.loader = loader;
+            this.commandService = commandService;
             this.logger = logger;
         }
 
@@ -32,7 +32,7 @@ namespace Brighid.Commands.Service
         public async Task StartAsync(CancellationToken cancellationToken)
         {
             logger.LogInformation("Pre-loading all embedded commands.");
-            await loader.LoadAllEmbeddedCommands(cancellationToken);
+            await commandService.LoadAllEmbeddedCommands(cancellationToken);
             logger.LogInformation("All embedded commands have been loaded.");
         }
 

--- a/src/Service/Commands/Models/CommandDownloadRequest.cs
+++ b/src/Service/Commands/Models/CommandDownloadRequest.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+
+namespace Brighid.Commands.Service
+{
+    /// <summary>
+    /// Represents a request to download a command.
+    /// </summary>
+    public struct CommandDownloadRequest
+    {
+        /// <summary>
+        /// Gets the assembly name.
+        /// </summary>
+        public string AssemblyName { get; init; }
+
+        /// <summary>
+        /// Gets the cancellation token.
+        /// </summary>
+        public CancellationToken CancellationToken { get; init; }
+    }
+}

--- a/src/Service/Commands/Services/DefaultCommandLoader.cs
+++ b/src/Service/Commands/Services/DefaultCommandLoader.cs
@@ -1,43 +1,62 @@
-using System.Linq;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Brighid.Commands.Sdk;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Brighid.Commands.Service
 {
     /// <inheritdoc />
     public class DefaultCommandLoader : ICommandLoader
     {
-        private readonly ICommandService service;
+        private readonly ICommandPackageDownloader downloader;
+        private readonly ICommandCache commandCache;
+        private readonly ILoggerFactory loggerFactory;
+        private readonly IUtilsFactory utilsFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultCommandLoader"/> class.
         /// </summary>
-        /// <param name="service">Service for managing commands.</param>
+        /// <param name="downloader">Service used for downloading command packages.</param>
+        /// <param name="commandCache">Cache for name to command lookups.</param>
+        /// <param name="utilsFactory">Factory to create utils with.</param>
+        /// <param name="loggerFactory">Logger factory to inject into the command's service collection.</param>
         public DefaultCommandLoader(
-            ICommandService service
+            ICommandPackageDownloader downloader,
+            ICommandCache commandCache,
+            IUtilsFactory utilsFactory,
+            ILoggerFactory loggerFactory
         )
         {
-            this.service = service;
+            this.downloader = downloader;
+            this.commandCache = commandCache;
+            this.utilsFactory = utilsFactory;
+            this.loggerFactory = loggerFactory;
         }
 
         /// <inheritdoc />
-        public async Task LoadAllEmbeddedCommands(CancellationToken cancellationToken)
+        public async Task<ICommandRunner> LoadEmbedded(Command command, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var commands = await service.ListByType(CommandType.Embedded, cancellationToken);
-            var tasks = from command in commands select service.LoadEmbedded(command, cancellationToken);
-            await Task.WhenAll(tasks);
-        }
-
-        /// <inheritdoc />
-        public async Task LoadCommand(Command command, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            command.Runner = command.Type switch
+            if (commandCache.TryGetValue(command.Name!, out var cachedCommand))
             {
-                CommandType.Embedded => await service.LoadEmbedded(command, cancellationToken),
-                _ => throw new CommandTypeNotSupportedException(command.Type),
-            };
+                return cachedCommand;
+            }
+
+            var assembly = await downloader.DownloadCommandPackageFromS3(command.EmbeddedLocation!.DownloadURL!, command.EmbeddedLocation.AssemblyName!, cancellationToken);
+            var registratorType = assembly.GetType(command.EmbeddedLocation.TypeName, false) ?? throw new CommandNotFoundException(command.Name);
+            var registrator = (ICommandRegistrator)(Activator.CreateInstance(registratorType, Array.Empty<object>()) ?? throw new CommandNotFoundException(command.Name));
+
+            var services = utilsFactory.CreateServiceCollection();
+            services.AddSingleton(loggerFactory);
+            services.AddLogging();
+
+            var runner = registrator.Register(services);
+            commandCache.Add(command.Name, runner);
+            return runner;
         }
     }
 }

--- a/src/Service/Commands/Services/ICommandLoader.cs
+++ b/src/Service/Commands/Services/ICommandLoader.cs
@@ -1,6 +1,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+using Brighid.Commands.Sdk;
+
 namespace Brighid.Commands.Service
 {
     /// <summary>
@@ -9,18 +11,11 @@ namespace Brighid.Commands.Service
     public interface ICommandLoader
     {
         /// <summary>
-        /// Loads all embedded commands.
+        /// Loads an embedded command into the assembly load context.
         /// </summary>
+        /// <param name="command">The command to load.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The resulting task.</returns>
-        Task LoadAllEmbeddedCommands(CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Loads a command by name.
-        /// </summary>
-        /// <param name="command">Command to load.</param>
-        /// <param name="cancellationToken">Token used to cancel the operation.</param>
-        /// <returns>The resulting command.</returns>
-        Task LoadCommand(Command command, CancellationToken cancellationToken);
+        Task<ICommandRunner> LoadEmbedded(Command command, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Service/Commands/Services/ICommandService.cs
+++ b/src/Service/Commands/Services/ICommandService.cs
@@ -3,8 +3,6 @@ using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Brighid.Commands.Sdk;
-
 namespace Brighid.Commands.Service
 {
     /// <summary>
@@ -65,12 +63,19 @@ namespace Brighid.Commands.Service
         Task<Command> DeleteByName(string name, ClaimsPrincipal principal, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Loads an embedded command into the assembly load context.
+        /// Loads all embedded commands.
         /// </summary>
-        /// <param name="command">The command to load.</param>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The resulting task.</returns>
-        Task<ICommandRunner> LoadEmbedded(Command command, CancellationToken cancellationToken = default);
+        Task LoadAllEmbeddedCommands(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Loads a command by name.
+        /// </summary>
+        /// <param name="command">Command to load.</param>
+        /// <param name="cancellationToken">Token used to cancel the operation.</param>
+        /// <returns>The resulting command.</returns>
+        Task LoadCommand(Command command, CancellationToken cancellationToken);
 
         /// <summary>
         /// Ensures that a command is accessible to the given <paramref name="principal" />.  If not,

--- a/tests/Service/Commands/HostedService/CommandLoaderBackgroundServiceTests.cs
+++ b/tests/Service/Commands/HostedService/CommandLoaderBackgroundServiceTests.cs
@@ -12,21 +12,21 @@ using static NSubstitute.Arg;
 
 namespace Brighid.Commands.Service
 {
-    public class StartupCommandLoaderTests
+    public class CommandLoaderBackgroundServiceTests
     {
         [TestFixture]
         public class StartAsyncTests
         {
             [Test, Auto]
             public async Task ShouldLoadAllEmbeddedCommands(
-                [Frozen, Substitute] ICommandLoader commandLoader,
-                [Target] StartupCommandLoader loader,
+                [Frozen, Substitute] ICommandService service,
+                [Target] CommandLoaderBackgroundService loader,
                 CancellationToken cancellationToken
             )
             {
                 await loader.StartAsync(cancellationToken);
 
-                await commandLoader.Received().LoadAllEmbeddedCommands(Is(cancellationToken));
+                await service.Received().LoadAllEmbeddedCommands(Is(cancellationToken));
             }
         }
     }


### PR DESCRIPTION
* Downloads commands on create/update if they are embedded commands.
* Also handles BRGD-109 Handle Package Download Concurrency.
* Reorganizes command service and loader service, so that the command loader service is a private service, and the command service is the primary entrypoint for loading commands.