### PR TITLE
BRGD-189 Use Source System/ID Headers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       Database__Name: ${DB_NAME}
       Database__User: ${DB_USER}
       Database__Password: ${DB_PASSWORD}
+      Auth__MetadataAddress: ${IDENTITY_METADATA_URL}
+      Auth__ValidIssuer: ${IDENTITY_ISSUER}
       SkipSwagger: "true"
     labels:
       - traefik.enable=true

--- a/tests/Service/Commands/Controllers/CommandControllerTests.cs
+++ b/tests/Service/Commands/Controllers/CommandControllerTests.cs
@@ -280,6 +280,48 @@ namespace Brighid.Commands.Service
             }
 
             [Test, Auto]
+            public async Task ShouldExecuteTheLoadedCommandAndPassSourceSystem(
+                string commandName,
+                string sourceSystem,
+                [Substitute] HttpContext httpContext,
+                ExecuteCommandRequest request,
+                [Frozen] ICommandRunner runner,
+                [Frozen, Substitute] ICommandLoader loader,
+                [Target] CommandController controller
+            )
+            {
+                controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+                await controller.Execute(commandName, sourceSystem);
+
+                await runner.Received().Run(
+                    Is<CommandContext>(context => context.SourceSystem == sourceSystem),
+                    Is(httpContext.RequestAborted)
+                );
+            }
+
+            [Test, Auto]
+            public async Task ShouldExecuteTheLoadedCommandAndPassSourceSystemId(
+                string commandName,
+                string sourceSystemId,
+                [Substitute] HttpContext httpContext,
+                ExecuteCommandRequest request,
+                [Frozen] ICommandRunner runner,
+                [Frozen, Substitute] ICommandLoader loader,
+                [Target] CommandController controller
+            )
+            {
+                controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+                await controller.Execute(commandName, sourceSystemId: sourceSystemId);
+
+                await runner.Received().Run(
+                    Is<CommandContext>(context => context.SourceSystemId == sourceSystemId),
+                    Is(httpContext.RequestAborted)
+                );
+            }
+
+            [Test, Auto]
             public async Task ShouldRespondWithCommandVersionIfCommandTypeIsEmbedded(
                 string commandName,
                 HttpContext httpContext,


### PR DESCRIPTION
Utilizes the x-source-system and x-source-system-id header values and passes them into command contexts.